### PR TITLE
Country List and Explorer List Directives

### DIFF
--- a/client/ngapp/build/main.js
+++ b/client/ngapp/build/main.js
@@ -37,8 +37,11 @@ angular
     $locationProvider.html5Mode(true);
   })
   // Things to run before the app loads;
-  .run(function ($rootScope, $location) {
-
+  .run(function ($rootScope, $location, $anchorScroll) {
+    $rootScope.$on('$routeChangeSuccess', function (newRoute, oldRoute) {
+      console.log($location.hash())
+      if($location.hash()) $anchorScroll();
+    });
     $rootScope.$location = $location;
   });
 ;'use strict';
@@ -52,9 +55,9 @@ angular
  */
 
 angular.module('ooniAPIApp')
-  .controller('CountryDetailViewCtrl', function ($q, $scope, $rootScope, $filter, Report, $http, $routeParams, ISO3166) {
+  .controller('CountryDetailViewCtrl', function ($q, $scope, $rootScope, $filter, Report, $http, $routeParams, ISO3166, $anchorScroll, $location) {
+
     $scope.loaded = false;
-    console.log('country controller loaded', moment().unix())
 
     $scope.countryCode = $routeParams.id;
     $scope.countryName = ISO3166.getCountryName($scope.countryCode);
@@ -161,7 +164,6 @@ angular.module('ooniAPIApp')
       Report.find(query, function(data) {
         deferred.resolve(data);
         $scope.loaded = true;
-        console.log('finished loading country data', moment().unix())
       });
 
       return deferred.promise;
@@ -185,6 +187,7 @@ angular.module('ooniAPIApp')
                                            $rootScope) {
 
     $scope.loadMeasurements = function(queryOptions) {
+      console.log('loading measurements')
 
       $scope.loaded = false;
 
@@ -207,6 +210,7 @@ angular.module('ooniAPIApp')
       }
 
       Report.find(query, function(data) {
+        console.log('found')
         deferred.resolve(data);
 
         $scope.loaded = true;
@@ -1324,7 +1328,6 @@ angular.module('ooniAPIApp')
         getDataFunction: '='
       },
       link: function ($scope) {
-        console.log('linking')
         var assignData = function (response) {
           $scope.countries = response.sort(function (a, b) {
             return a.name > b.name
@@ -1334,6 +1337,29 @@ angular.module('ooniAPIApp')
         $scope.getDataFunction({}).then(assignData)
       },
       templateUrl: 'views/directives/ooni-info-country-list.directive.html'
+    }
+  })
+
+.directive('ooniInfoExplorerList',
+  function () {
+    return {
+      restrict: 'A',
+      scope: {
+        getDataFunction: '='
+      },
+      link: function ($scope) {
+        console.log('loaded explorer list')
+        $scope.encodeInput = window.encodeURIComponent
+
+        var assignData = function (response) {
+          $scope.objects = response.sort(function (a, b) {
+            return a.name > b.name
+          })
+        }
+
+        $scope.getDataFunction({}).then(assignData)
+      },
+      templateUrl: 'views/directives/ooni-info-explorer-list.directive.html'
     }
   })
 ;;(function(window, angular, undefined) {'use strict';

--- a/client/ngapp/build/main.js
+++ b/client/ngapp/build/main.js
@@ -1327,6 +1327,7 @@ angular.module('ooniAPIApp')
         getDataFunction: '='
       },
       link: function ($scope) {
+
         var assignData = function (response) {
           $scope.countries = response.sort(function (a, b) {
             return a.name > b.name

--- a/client/ngapp/build/main.js
+++ b/client/ngapp/build/main.js
@@ -331,18 +331,6 @@ var definitions = {
 }
 
 ;angular.module('ooniAPIApp')
-.controller('HTTPRequestsViewCtrl', function ($scope){
-    angular.forEach($scope.report.test_keys.requests, function(request){
-        if (request.request.tor == true || request.request.tor.is_tor == true) {
-            $scope.control = request.response;
-        } else {
-            $scope.experiment = request.response;
-        }
-    })
-})
-.controller('DNSConsistencyViewCtrl', function ($scope, $location){
-});
-;angular.module('ooniAPIApp')
 .controller('HTTPRequestsViewCtrl', function ($scope, $location){
 
   $scope.encodeInput = window.encodeURIComponent;
@@ -384,6 +372,9 @@ var definitions = {
   }
   if ($scope.experiment_failure !== 'none' && ($scope.control_failure === 'none' || $scope.control_failure === 'unknown')) {
     $scope.anomaly = true;
+  }
+  if ($scope.report.test_keys.headers_match == false) {
+       $scope.anomaly = true;
   }
 
   $scope.header_names = [];
@@ -434,7 +425,7 @@ angular.module('ooniAPIApp')
           nettestSlug = $scope.report.test_name.replace('_', '-');
         }
         var url = '/views/nettests/' + nettestSlug + '.html';
-        return url;
+        return url
       }
     },
     template: '<div ng-include="getContentUrl()">fasdfdas</div>'
@@ -538,30 +529,6 @@ angular.module('ooniAPIApp')
       alpha3: {},
       alpha2: {}
     };
-
-    $scope.columnDefs = [{
-        name: 'Country Code',
-        field:'alpha2'
-    },
-    {
-        name: 'Country Name',
-        field:'name'
-    },
-    {
-        name: 'Count',
-        field:'count',
-        sortingAlgorithm: function(a, b) {
-            a = parseInt(a);
-            b = parseInt(b);
-            if (a > b) {
-                return 1;
-            } else if (a < b) {
-                return -1;
-            } else {
-                return 0;
-            }
-        }
-    }]
 
     $scope.worldMap = {
         scope: 'world',
@@ -674,6 +641,7 @@ angular.module('ooniAPIApp')
                       $scope.worldMap.data[country.alpha3]["fillKey"] = "HIGH";
                   }
               })
+
               $scope.loaded = true;
               deferred.resolve($scope.reportsByCountry);
           }, function(err, resp){
@@ -1347,6 +1315,27 @@ angular.module('ooniAPIApp')
       templateUrl: 'views/directives/ooni-country-bar-chart.directive.html',
     };
 })
+
+.directive('ooniInfoCountryList',
+  function () {
+    return {
+      restrict: 'A',
+      scope: {
+        getDataFunction: '='
+      },
+      link: function ($scope) {
+        console.log('linking')
+        var assignData = function (response) {
+          $scope.countries = response.sort(function (a, b) {
+            return a.name > b.name
+          })
+        }
+
+        $scope.getDataFunction({}).then(assignData)
+      },
+      templateUrl: 'views/directives/ooni-info-country-list.directive.html'
+    }
+  })
 ;;(function(window, angular, undefined) {'use strict';
 
 var urlBase = "/api";

--- a/client/ngapp/scripts/app.js
+++ b/client/ngapp/scripts/app.js
@@ -37,7 +37,10 @@ angular
     $locationProvider.html5Mode(true);
   })
   // Things to run before the app loads;
-  .run(function ($rootScope, $location) {
-
+  .run(function ($rootScope, $location, $anchorScroll) {
+    $rootScope.$on('$routeChangeSuccess', function (newRoute, oldRoute) {
+      console.log($location.hash())
+      if($location.hash()) $anchorScroll();
+    });
     $rootScope.$location = $location;
   });

--- a/client/ngapp/scripts/app.js
+++ b/client/ngapp/scripts/app.js
@@ -38,9 +38,5 @@ angular
   })
   // Things to run before the app loads;
   .run(function ($rootScope, $location, $anchorScroll) {
-    $rootScope.$on('$routeChangeSuccess', function (newRoute, oldRoute) {
-      console.log($location.hash())
-      if($location.hash()) $anchorScroll();
-    });
     $rootScope.$location = $location;
   });

--- a/client/ngapp/scripts/controllers/country.js
+++ b/client/ngapp/scripts/controllers/country.js
@@ -9,9 +9,9 @@
  */
 
 angular.module('ooniAPIApp')
-  .controller('CountryDetailViewCtrl', function ($q, $scope, $rootScope, $filter, Report, $http, $routeParams, ISO3166) {
+  .controller('CountryDetailViewCtrl', function ($q, $scope, $rootScope, $filter, Report, $http, $routeParams, ISO3166, $anchorScroll, $location) {
+
     $scope.loaded = false;
-    console.log('country controller loaded', moment().unix())
 
     $scope.countryCode = $routeParams.id;
     $scope.countryName = ISO3166.getCountryName($scope.countryCode);
@@ -118,7 +118,6 @@ angular.module('ooniAPIApp')
       Report.find(query, function(data) {
         deferred.resolve(data);
         $scope.loaded = true;
-        console.log('finished loading country data', moment().unix())
       });
 
       return deferred.promise;

--- a/client/ngapp/scripts/controllers/explore.js
+++ b/client/ngapp/scripts/controllers/explore.js
@@ -15,7 +15,6 @@ angular.module('ooniAPIApp')
                                            $rootScope) {
 
     $scope.loadMeasurements = function(queryOptions) {
-      console.log('loading measurements')
 
       $scope.loaded = false;
 
@@ -37,12 +36,16 @@ angular.module('ooniAPIApp')
           }
       }
 
-      Report.find(query, function(data) {
-        console.log('found')
-        deferred.resolve(data);
+      Report.count(query, function (count) {
+        Report.find(query, function(data) {
+          data.total = count.count
+          deferred.resolve(data);
 
-        $scope.loaded = true;
-      });
+          $scope.loaded = true;
+        });
+      })
+
+
 
       return deferred.promise;
     }

--- a/client/ngapp/scripts/controllers/explore.js
+++ b/client/ngapp/scripts/controllers/explore.js
@@ -15,6 +15,7 @@ angular.module('ooniAPIApp')
                                            $rootScope) {
 
     $scope.loadMeasurements = function(queryOptions) {
+      console.log('loading measurements')
 
       $scope.loaded = false;
 
@@ -37,6 +38,7 @@ angular.module('ooniAPIApp')
       }
 
       Report.find(query, function(data) {
+        console.log('found')
         deferred.resolve(data);
 
         $scope.loaded = true;

--- a/client/ngapp/scripts/controllers/nettests/nettests.js
+++ b/client/ngapp/scripts/controllers/nettests/nettests.js
@@ -21,7 +21,7 @@ angular.module('ooniAPIApp')
           nettestSlug = $scope.report.test_name.replace('_', '-');
         }
         var url = '/views/nettests/' + nettestSlug + '.html';
-        return url;
+        return url
       }
     },
     template: '<div ng-include="getContentUrl()">fasdfdas</div>'

--- a/client/ngapp/scripts/controllers/world.js
+++ b/client/ngapp/scripts/controllers/world.js
@@ -18,30 +18,6 @@ angular.module('ooniAPIApp')
       alpha2: {}
     };
 
-    $scope.columnDefs = [{
-        name: 'Country Code',
-        field:'alpha2'
-    },
-    {
-        name: 'Country Name',
-        field:'name'
-    },
-    {
-        name: 'Count',
-        field:'count',
-        sortingAlgorithm: function(a, b) {
-            a = parseInt(a);
-            b = parseInt(b);
-            if (a > b) {
-                return 1;
-            } else if (a < b) {
-                return -1;
-            } else {
-                return 0;
-            }
-        }
-    }]
-
     $scope.worldMap = {
         scope: 'world',
         responsive: true,
@@ -153,6 +129,7 @@ angular.module('ooniAPIApp')
                       $scope.worldMap.data[country.alpha3]["fillKey"] = "HIGH";
                   }
               })
+
               $scope.loaded = true;
               deferred.resolve($scope.reportsByCountry);
           }, function(err, resp){

--- a/client/ngapp/scripts/directives/directives.js
+++ b/client/ngapp/scripts/directives/directives.js
@@ -426,7 +426,7 @@ angular.module('ooniAPIApp')
   })
 
 .directive('ooniInfoExplorerList',
-  function () {
+  function (Nettest) {
     return {
       restrict: 'A',
       scope: {
@@ -434,6 +434,82 @@ angular.module('ooniAPIApp')
       },
       link: function ($scope) {
         console.log('loaded explorer list')
+
+        $scope.queryOptions = {}
+        $scope.queryOptions.pageNumber = 0
+        $scope.queryOptions.pageSize = 100
+
+        $scope.queryOptions.order = 'test_start_time DESC'
+        $scope.queryOptions.where = {}
+
+        $scope.filterCallback = function() {
+          $scope.getDataFunction($scope.queryOptions).then(assignData)
+        }
+
+        var assignData = function (response) {
+          $scope.measurements = response
+          $scope.total = Math.floor($scope.measurements.total / $scope.queryOptions.pageSize)
+          console.log($scope.total)
+          console.log('assigning data')
+        }
+
+        $scope.goTo = function (page) {
+          console.log('going to')
+          $scope.queryOptions.pageNumber = page
+          $scope.getDataFunction($scope.queryOptions).then(assignData)
+        }
+
+        $scope.getDataFunction($scope.queryOptions).then(assignData)
+      },
+      templateUrl: 'views/directives/ooni-info-explorer-list.directive.html'
+    }
+  })
+
+.directive('ooniPagination',
+  function () {
+    return {
+      restrict: 'A',
+      scope: {
+        pageNumber: '=',
+        goTo: '=',
+        total: '=',
+        pageSize: '='
+      },
+      templateUrl: 'views/directives/ooni-pagination.directive.html'
+    }
+  })
+
+.directive('ooniExplorerListMeasurement',
+  function () {
+    return {
+      restrict: 'A',
+      scope: {
+        measurement: '=ooniExplorerListMeasurement'
+
+      },
+      link: function ($scope) {
+        $scope.encodeInput = window.encodeURIComponent
+      },
+      templateUrl: 'views/directives/ooni-explorer-list-measurement.directive.html'
+    }
+  })
+
+.directive('ooniFilterListForm',
+  function (Nettest) {
+    return {
+      restrict: 'A',
+      scope: {
+        queryOptions: '=',
+        afterFilter: '='
+      },
+      link: function ($scope) {
+        $scope.encodeInput = window.encodeURIComponent
+        $scope.inputFilter = ''
+        $scope.testNameFilter = ''
+        $scope.countryCodeFilter = ''
+        $scope.startDateFilter = ''
+        $scope.endDateFilter = ''
+        $scope.nettests = Nettest.find()
 
         $scope.dateRangePicker = {}
 
@@ -452,52 +528,29 @@ angular.module('ooniAPIApp')
           }
         }
 
-        $scope.encodeInput = window.encodeURIComponent
+        $scope.filterMeasurements = function () {
+          $scope.queryOptions.where = {}
+          if ($scope.inputFilter.length > 0) {
+            $scope.queryOptions.where['input'] = {'like': '%' + $scope.inputFilter + '%'}
+          }
+          if ($scope.testNameFilter.length > 0) {
+            $scope.queryOptions.where['test_name'] = $scope.testNameFilter
+          }
+          if ($scope.countryCodeFilter.length > 0) {
+            $scope.queryOptions.where['probe_cc'] = $scope.countryCodeFilter
+          }
+          var start, end
+          if ($scope.dateRangePicker.date.startDate && $scope.dateRangePicker.date.endDate) {
+            start = $scope.dateRangePicker.date.startDate.hours(0).minutes(0).toISOString()
+            end = $scope.dateRangePicker.date.endDate.hours(0).minutes(0).toISOString()
+            $scope.queryOptions.where['test_start_time'] = {
+              between: [start, end]
+            }
+          }
 
-        $scope.queryOptions = {}
-        $scope.queryOptions.pageNumber = 0
-        $scope.queryOptions.pageSize = 100
-
-        $scope.queryOptions.order = 'test_start_time DESC'
-        $scope.queryOptions.where = {}
-
-        $scope.filterMeasurements = function() {
-            $scope.queryOptions.where = {};
-            if ($scope.inputFilter.length > 0) {
-                $scope.queryOptions.where['input'] = {'like': '%' + $scope.inputFilter + '%'};
-            }
-            if ($scope.testNameFilter.length > 0) {
-                $scope.queryOptions.where['test_name'] = $scope.testNameFilter;
-            }
-            if ($scope.countryCodeFilter.length > 0) {
-                $scope.queryOptions.where['probe_cc'] = $scope.countryCodeFilter;
-            }
-            var start, end;
-            if ($scope.dateRangePicker.date.startDate && $scope.dateRangePicker.date.endDate) {
-              start = $scope.dateRangePicker.date.startDate.hours(0).minutes(0).toISOString();
-              end = $scope.dateRangePicker.date.endDate.hours(0).minutes(0).toISOString();
-              $scope.queryOptions.where['test_start_time'] = {
-                between: [start, end]
-              }
-            }
-            $scope.getDataFunction($scope.queryOptions).then(assignData);
+          $scope.afterFilter()
         }
-
-        var assignData = function (response) {
-          $scope.measurements = response
-          $scope.total = Math.floor($scope.measurements.total/$scope.queryOptions.pageSize)
-          console.log($scope.measurements.total, $scope.queryOptions.pageSize)
-          console.log($scope.total)
-          console.log('assigning data')
-        }
-
-        $scope.goTo = function (page) {
-          $scope.queryOptions.pageNumber = page
-          $scope.getDataFunction($scope.queryOptions).then(assignData)
-        }
-
-        $scope.getDataFunction($scope.queryOptions).then(assignData)
       },
-      templateUrl: 'views/directives/ooni-info-explorer-list.directive.html'
+      templateUrl: 'views/directives/ooni-filter-list-form.directive.html'
     }
   })

--- a/client/ngapp/scripts/directives/directives.js
+++ b/client/ngapp/scripts/directives/directives.js
@@ -412,6 +412,7 @@ angular.module('ooniAPIApp')
         getDataFunction: '='
       },
       link: function ($scope) {
+
         var assignData = function (response) {
           $scope.countries = response.sort(function (a, b) {
             return a.name > b.name

--- a/client/ngapp/scripts/directives/directives.js
+++ b/client/ngapp/scripts/directives/directives.js
@@ -412,7 +412,6 @@ angular.module('ooniAPIApp')
         getDataFunction: '='
       },
       link: function ($scope) {
-        console.log('linking')
         var assignData = function (response) {
           $scope.countries = response.sort(function (a, b) {
             return a.name > b.name
@@ -422,5 +421,28 @@ angular.module('ooniAPIApp')
         $scope.getDataFunction({}).then(assignData)
       },
       templateUrl: 'views/directives/ooni-info-country-list.directive.html'
+    }
+  })
+
+.directive('ooniInfoExplorerList',
+  function () {
+    return {
+      restrict: 'A',
+      scope: {
+        getDataFunction: '='
+      },
+      link: function ($scope) {
+        console.log('loaded explorer list')
+        $scope.encodeInput = window.encodeURIComponent
+
+        var assignData = function (response) {
+          $scope.objects = response.sort(function (a, b) {
+            return a.name > b.name
+          })
+        }
+
+        $scope.getDataFunction({}).then(assignData)
+      },
+      templateUrl: 'views/directives/ooni-info-explorer-list.directive.html'
     }
   })

--- a/client/ngapp/scripts/directives/directives.js
+++ b/client/ngapp/scripts/directives/directives.js
@@ -403,3 +403,24 @@ angular.module('ooniAPIApp')
       templateUrl: 'views/directives/ooni-country-bar-chart.directive.html',
     };
 })
+
+.directive('ooniInfoCountryList',
+  function () {
+    return {
+      restrict: 'A',
+      scope: {
+        getDataFunction: '='
+      },
+      link: function ($scope) {
+        console.log('linking')
+        var assignData = function (response) {
+          $scope.countries = response.sort(function (a, b) {
+            return a.name > b.name
+          })
+        }
+
+        $scope.getDataFunction({}).then(assignData)
+      },
+      templateUrl: 'views/directives/ooni-info-country-list.directive.html'
+    }
+  })

--- a/client/ngapp/scripts/directives/directives.js
+++ b/client/ngapp/scripts/directives/directives.js
@@ -433,15 +433,69 @@ angular.module('ooniAPIApp')
       },
       link: function ($scope) {
         console.log('loaded explorer list')
-        $scope.encodeInput = window.encodeURIComponent
 
-        var assignData = function (response) {
-          $scope.objects = response.sort(function (a, b) {
-            return a.name > b.name
-          })
+        $scope.dateRangePicker = {}
+
+        $scope.dateRangePicker.date = {
+          startDate: null,
+          endDate: null
         }
 
-        $scope.getDataFunction({}).then(assignData)
+        $scope.dateRangePicker.options = {
+          maxDate: moment(),
+          autoUpdateInput: true,
+          eventHandlers: {
+            'cancel.daterangepicker': function(ev, picker) {
+              $scope.dateRangePicker.date = {startDate: null, endDate: null}
+            }
+          }
+        }
+
+        $scope.encodeInput = window.encodeURIComponent
+
+        $scope.queryOptions = {}
+        $scope.queryOptions.pageNumber = 0
+        $scope.queryOptions.pageSize = 100
+
+        $scope.queryOptions.order = 'test_start_time DESC'
+        $scope.queryOptions.where = {}
+
+        $scope.filterMeasurements = function() {
+            $scope.queryOptions.where = {};
+            if ($scope.inputFilter.length > 0) {
+                $scope.queryOptions.where['input'] = {'like': '%' + $scope.inputFilter + '%'};
+            }
+            if ($scope.testNameFilter.length > 0) {
+                $scope.queryOptions.where['test_name'] = $scope.testNameFilter;
+            }
+            if ($scope.countryCodeFilter.length > 0) {
+                $scope.queryOptions.where['probe_cc'] = $scope.countryCodeFilter;
+            }
+            var start, end;
+            if ($scope.dateRangePicker.date.startDate && $scope.dateRangePicker.date.endDate) {
+              start = $scope.dateRangePicker.date.startDate.hours(0).minutes(0).toISOString();
+              end = $scope.dateRangePicker.date.endDate.hours(0).minutes(0).toISOString();
+              $scope.queryOptions.where['test_start_time'] = {
+                between: [start, end]
+              }
+            }
+            $scope.getDataFunction($scope.queryOptions).then(assignData);
+        }
+
+        var assignData = function (response) {
+          $scope.measurements = response
+          $scope.total = Math.floor($scope.measurements.total/$scope.queryOptions.pageSize)
+          console.log($scope.measurements.total, $scope.queryOptions.pageSize)
+          console.log($scope.total)
+          console.log('assigning data')
+        }
+
+        $scope.goTo = function (page) {
+          $scope.queryOptions.pageNumber = page
+          $scope.getDataFunction($scope.queryOptions).then(assignData)
+        }
+
+        $scope.getDataFunction($scope.queryOptions).then(assignData)
       },
       templateUrl: 'views/directives/ooni-info-explorer-list.directive.html'
     }

--- a/client/ngapp/styles/_country.scss
+++ b/client/ngapp/styles/_country.scss
@@ -4,6 +4,10 @@
   }
 }
 
+.hang-right {
+  display: inline-block;
+}
+
 
 .map {
   margin-top: -80px;

--- a/client/ngapp/styles/_explore.scss
+++ b/client/ngapp/styles/_explore.scss
@@ -1,0 +1,15 @@
+.explore {
+  .explorer-list {
+    list-style: none;
+    margin: 0;
+
+    li {
+      margin: 0;
+    }
+  }
+}
+
+.column-1-5 {
+  width: 19%;
+  display: inline-block;
+}

--- a/client/ngapp/styles/_explore.scss
+++ b/client/ngapp/styles/_explore.scss
@@ -5,11 +5,37 @@
 
     li {
       margin: 0;
+      padding: .5rem;
+
+      &:nth-child(odd) {
+        background-color: $color-off-white;
+      }
     }
   }
-}
 
-.column-1-5 {
-  width: 19%;
-  display: inline-block;
+  .column {
+    display: inline-block;
+  }
+
+  .probe-cc {
+    width: 9%;
+  }
+
+  .name {
+    width: 37%;
+  }
+
+  .input {
+    width: 34%;
+  }
+
+  .probe-asn {
+    width: 9%;
+    text-align: right;
+  }
+
+  .start-time {
+    width: 9%;
+    text-align: right;
+  }
 }

--- a/client/ngapp/styles/_pagination.scss
+++ b/client/ngapp/styles/_pagination.scss
@@ -1,0 +1,5 @@
+.pagination {
+  li {
+    display: inline-block;
+  }
+}

--- a/client/ngapp/styles/_pagination.scss
+++ b/client/ngapp/styles/_pagination.scss
@@ -1,5 +1,0 @@
-.pagination {
-  li {
-    display: inline-block;
-  }
-}

--- a/client/ngapp/styles/_world.scss
+++ b/client/ngapp/styles/_world.scss
@@ -25,3 +25,27 @@
       }
     }
 }
+
+.countries-list {
+  list-style: none;
+  margin: 0;
+
+  li {
+    margin: 0;
+    padding: .5rem .5rem;
+
+    &:nth-child(odd) {
+      background-color: $color-off-white;
+    }
+  }
+  .country {
+    width: 35%;
+    display: inline-block;
+  }
+
+  .count {
+    width: 10%;
+    text-align: right;
+    display: inline-block;
+  }
+}

--- a/client/ngapp/styles/main.scss
+++ b/client/ngapp/styles/main.scss
@@ -23,6 +23,7 @@ $transition-speed: .5s;
 @import "ui/fonts",
         "ui/table",
         "ui/p",
+        "ui/table-of-contents",
         "ui/buttons",
         "ui/forms",
         "ui/ui-grid",

--- a/client/ngapp/styles/main.scss
+++ b/client/ngapp/styles/main.scss
@@ -23,6 +23,7 @@ $transition-speed: .5s;
 @import "ui/fonts",
         "ui/table",
         "ui/p",
+        "ui/pagination",
         "ui/table-of-contents",
         "ui/buttons",
         "ui/forms",
@@ -32,6 +33,7 @@ $transition-speed: .5s;
         "base",
         "loading",
         "country",
+        "explore",
         "report",
         "world";
 

--- a/client/ngapp/styles/ui/_pagination.scss
+++ b/client/ngapp/styles/ui/_pagination.scss
@@ -1,0 +1,5 @@
+.pagination {
+  li {
+    display: inline-block;
+  }
+}

--- a/client/ngapp/styles/ui/_pagination.scss
+++ b/client/ngapp/styles/ui/_pagination.scss
@@ -1,5 +1,26 @@
 .pagination {
+  margin: 0 1rem 1rem 0;
+  display: inline-block;
+
   li {
     display: inline-block;
+    margin: 0;
+    padding: .25rem .5rem;
+    border: 1px solid $color-off-white;
+    border-right: 0px;
+  }
+
+  a {
+    cursor: pointer;
+  }
+
+  li:last-child {
+    border-top-right-radius: 3px;
+    border-bottom-right-radius: 3px;
+    border-right: 1px solid $color-off-white;
+  }
+  li:first-child {
+    border-top-left-radius: 3px;
+    border-bottom-left-radius: 3px;
   }
 }

--- a/client/ngapp/styles/ui/_table-of-contents.scss
+++ b/client/ngapp/styles/ui/_table-of-contents.scss
@@ -1,0 +1,19 @@
+.toc {
+
+  border: 1px solid $color-grey;
+  padding: .5rem 1rem;
+  display: inline-block;
+  list-style: none;
+  vertical-align: top;
+  margin-right: .5rem;
+  font-size: 14px;
+
+  li {
+    padding: 0;
+    margin: 0;
+  }
+
+  a {
+    cursor: pointer;
+  }
+}

--- a/client/ngapp/views/country-view.html
+++ b/client/ngapp/views/country-view.html
@@ -7,15 +7,39 @@
       </h1>
     </div>
 
-    <p>
-      Here's what we know about anomalies with internet connections located in <span class="capitalize">{{ countryName | lowercase }}</span>.
-    </p>
+    <ul class="toc">
+      <li ng-show="blockpageCount">
+        <a href="#blockpageCount-bar-chart">Bar Chart</a>
+      </li>
+      <li>
+        <a href="#measurements">Measurements</a>
+      </li>
+      <li>
+        <a href="#country-data">Country Data</a>
+      </li>
+      <li>
+        <a href="#methods">Methods</a>
+      </li>
+      <li>
+        <a href="#vendors">Vendors</a>
+      </li>
+      <li ng-show="blockpageCount">
+        <a href="#vendors">Blocked Sites</a>
+      </li>
+    </ul>
 
-    <p>
-      <h4>We've got {{ count | number }} measurements for <span class="capitalize">{{ countryName | lowercase }}</span>.</h4>
-    </p>
+    <div class="hang-right">
 
-    <div ooni-country-bar-chart
+      <p>
+        Here's what we know about anomalies with internet connections located in <span class="capitalize">{{ countryName | lowercase }}</span>.
+      </p>
+
+      <p>
+        <h4>We've got {{ count | number }} measurements for <span class="capitalize">{{ countryName | lowercase }}</span>.</h4>
+      </p>
+    </div>
+
+    <div id="bar-chart" ooni-country-bar-chart
       country-data="blockpageCount"
       ng-show="blockpageCount">
     </div>
@@ -24,12 +48,12 @@
       loaded="loaded">
     </div>
 
-    <div ooni-grid-wrapper
+    <div id="measurements" ooni-grid-wrapper
       get-data-function="loadMeasurements"
       total-items="count">
     </div>
 
-    <div class="statistics">
+    <div class="statistics" id="country-data">
     <h2>
       Country Internet Statistics
     </h2>
@@ -58,12 +82,12 @@
     </table>
     </div>
 
-    <section class="reasons">
+    <section class="reasons" id="methods">
       <h2>Methods of Censorship</h2>
 
     </div>
 
-    <section class="vendors">
+    <section class="vendors" id="vendors">
       <h2>Identified Vendors</h2>
       <ul ng-show="vendors.length > 0">
         <li ng-repeat="vendor in vendors">
@@ -78,7 +102,7 @@
       </div>
     </section>
 
-    <section class="websites-blocked">
+    <section class="websites-blocked" id="blocked-sites">
       <h2>Blocked Websites</h2>
       <ul ng-show="blockpageList.length > 0">
         <li ng-repeat="obj in loadedChunks track by $index">

--- a/client/ngapp/views/country-view.html
+++ b/client/ngapp/views/country-view.html
@@ -24,7 +24,7 @@
         <a href="#vendors">Vendors</a>
       </li>
       <li ng-show="blockpageCount">
-        <a href="#vendors">Blocked Sites</a>
+        <a href="#blocked-sites">Blocked Sites</a>
       </li>
     </ul>
 

--- a/client/ngapp/views/directives/ooni-explorer-list-measurement.directive.html
+++ b/client/ngapp/views/directives/ooni-explorer-list-measurement.directive.html
@@ -1,0 +1,22 @@
+<div class="column probe-cc">
+  <a href="/country/{{measurement.probe_cc}}" title="View {{measurement.probe_cc}}"><i class="flag-icon" ng-class="'flag-icon-' + measurement.probe_cc | lowercase"></i> {{ measurement.probe_cc}}</a>
+</div>
+<div class="column name">{{ measurement.test_name }}
+  <a title="View Measurement"
+  href="/measurement/{{ measurement.id }}{{ measurement.input ? '?input=' + encodeInput(measurement.input) : '' }}">
+    <small ng-show="$parent.$index === 0">
+      View measurement »</small>
+    <small ng-show="$parent.$index > 0">View »</small>
+  </a>
+</div>
+<div class="column input">{{ measurement.input }}
+<a title="View Website"
+  ng-show="measurement.input"
+  href="/website/{{ encodeInput(measurement.input.replace('http://', '')) }}">
+    <small ng-show="$parent.$index === 0">
+      View Page Information »</small>
+    <small ng-show="$parent.$index > 0">View »</small>
+  </a>
+</div>
+<div class="column probe-asn">{{ measurement.probe_asn }}</div>
+<div class="column start-time">{{ measurement.test_start_time|date:'shortDate' }}</div>

--- a/client/ngapp/views/directives/ooni-filter-list-form.directive.html
+++ b/client/ngapp/views/directives/ooni-filter-list-form.directive.html
@@ -1,0 +1,40 @@
+<a ng-click="filterFormOpen = !filterFormOpen" class="filter-toggle" ng-show="!hideFilter">
+  Filter Results
+    <i class="fa fa-chevron-circle-down" ng-class="{open: filterFormOpen}"></i>
+</a>
+
+<form class="filter-form" ng-show="filterFormOpen && !hideFilter">
+  <div class="form-group inline">
+    <label class="sr-only" for="input">Test Input:</label>
+    <input type="text" class="form-control" ng-model="inputFilter" placeholder="Test Input"/>
+  </div>
+  <div class="form-group inline">
+    <label class="sr-only" for="testName">Test Name:</label>
+    <select name="repeatSelect" id="repeatSelect" ng-model="testNameFilter">
+        <option value="">-- Select Nettest --</option>
+        <option ng-repeat="option in nettests" value="{{option.name}}">{{option.long_name}}</option>
+    </select>
+  </div>
+  <div class="form-group" ng-show="countryCodes">
+    <label class="sr-only" for="countryCode">Country Code:</label>
+
+    <select name="repeatSelectCountry"
+      id="countryCode"
+      ng-model="countryCodeFilter"
+      ng-options="key as value for (key, value) in allCountryCodes">
+        <option value="">-- Select Country Code --</option>
+    </select>
+    <!-- <input type="text" class="form-control" ng-model="countryCodeFilter" placeholder="Country code"/> -->
+  </div>
+  <br ng-show="!countryCodes"/>
+
+  <div class="form-group inline date-range">
+    <label>Date Range</label>
+    <input date-range-picker
+      class="form-control date-picker"
+      type="text"
+      ng-model="dateRangePicker.date"
+      options="dateRangePicker.options"/>
+  </div>
+  <button class="form-group" type="submit" ng-click="filterMeasurements()">Apply Filter</button>
+</form>

--- a/client/ngapp/views/directives/ooni-info-country-list.directive.html
+++ b/client/ngapp/views/directives/ooni-info-country-list.directive.html
@@ -1,7 +1,9 @@
 
 <form class="filter-form">
-<label>Filter:</label>
-<input placeholder="eg. Iran" ng-model="countryFilter"/>
+<div class="form-group inline">
+  <label>Filter:</label>
+  <input placeholder="eg. Iran" ng-model="countryFilter"/>
+</div>
 </form>
 
 <ul class="countries-list">

--- a/client/ngapp/views/directives/ooni-info-country-list.directive.html
+++ b/client/ngapp/views/directives/ooni-info-country-list.directive.html
@@ -1,0 +1,5 @@
+<ul>
+  <li ng-repeat="country in countries">
+    <i class="flag-icon" ng-class="'flag-icon-' + country.alpha2 | lowercase"></i> <a href="/country/{{country.alpha2}}/">{{ country.name }}</a> - {{ country.count }}
+  </li>
+</ul>

--- a/client/ngapp/views/directives/ooni-info-country-list.directive.html
+++ b/client/ngapp/views/directives/ooni-info-country-list.directive.html
@@ -1,5 +1,13 @@
-<ul>
-  <li ng-repeat="country in countries">
-    <i class="flag-icon" ng-class="'flag-icon-' + country.alpha2 | lowercase"></i> <a href="/country/{{country.alpha2}}/">{{ country.name }}</a> - {{ country.count }}
+
+<form class="filter-form">
+<label>Filter:</label>
+<input placeholder="eg. Iran" ng-model="countryFilter"/>
+</form>
+
+<ul class="countries-list">
+  <li ng-repeat="country in countries | filter: countryFilter">
+    <a href="/country/{{country.alpha2}}/" class="country">
+      <i class="flag-icon" ng-class="'flag-icon-' + country.alpha2 | lowercase"></i> {{ country.name }}</a>
+      <span class="count">{{ country.count|number }}</span> <span ng-if="$index === 0">measurements run</span>
   </li>
 </ul>

--- a/client/ngapp/views/directives/ooni-info-explorer-list.directive.html
+++ b/client/ngapp/views/directives/ooni-info-explorer-list.directive.html
@@ -1,0 +1,70 @@
+<a ng-click="filterFormOpen = !filterFormOpen" class="filter-toggle" ng-show="!hideFilter">
+  Filter Results
+    <i class="fa fa-chevron-circle-down" ng-class="{open: filterFormOpen}"></i>
+</a>
+<form class="filter-form" ng-show="filterFormOpen && !hideFilter">
+  <div class="form-group inline">
+    <label class="sr-only" for="input">Test Input:</label>
+    <input type="text" class="form-control" ng-model="inputFilter" placeholder="Test Input"/>
+  </div>
+  <div class="form-group inline">
+    <label class="sr-only" for="testName">Test Name:</label>
+    <select name="repeatSelect" id="repeatSelect" ng-model="testNameFilter">
+        <option value="">-- Select Nettest --</option>
+        <option ng-repeat="option in nettests" value="{{option.name}}">{{option.long_name}}</option>
+    </select>
+  </div>
+  <div class="form-group" ng-show="countryCodes">
+    <label class="sr-only" for="countryCode">Country Code:</label>
+
+    <select name="repeatSelectCountry"
+      id="countryCode"
+      ng-model="countryCodeFilter"
+      ng-options="key as value for (key, value) in allCountryCodes">
+        <option value="">-- Select Country Code --</option>
+    </select>
+    <!-- <input type="text" class="form-control" ng-model="countryCodeFilter" placeholder="Country code"/> -->
+  </div>
+  <br ng-show="!countryCodes"/>
+
+  <div class="form-group inline date-range">
+    <label>Date Range</label>
+    <input date-range-picker
+      class="form-control date-picker"
+      type="text"
+      ng-model="dateRangePicker.date"
+      options="dateRangePicker.options"/>
+  </div>
+  <button class="form-group" type="submit" ng-click="filterMeasurements()">Apply Filter</button>
+</form>
+
+<ul class="explorer-list">
+  <li ng-repeat="measurement in measurements">
+    <div class="column-1-5">
+      <a href="/measurement/{{ measurement.report_id }}?input={{ encodeInput(measurement.input) }}">{{ measurement.probe_cc}}</a>
+    </div>
+    <div class="column-1-5">{{measurement.test_name}}</div>
+    <div class="column-1-5">{{measurement.input}}</div>
+    <div class="column-1-5">{{measurement.probe_asn}}</div>
+    <div class="column-1-5">{{measurement.test_start_time|date:'shortDate'}}</div>
+  </li>
+</ul>
+
+<ul class="pagination">
+  <li ng-hide="queryOptions.pageNumber <= 0">
+    <a ng-click="goTo(queryOptions.pageNumber - 1)">< Previous</a>
+  </li>
+  <li>
+  </li>
+  <li>
+    {{ queryOptions.pageNumber }}
+  </li>
+  <li ng-hide="queryOptions.pageNumber >= Math.floor(measurements.total / queryOptions.pageSize)">
+    <a ng-click="goTo(queryOptions.pageNumber + 1)">Next ></a>
+  </li>
+  <li>
+    {{ total }} total
+  </li>
+</ul>
+
+

--- a/client/ngapp/views/directives/ooni-info-explorer-list.directive.html
+++ b/client/ngapp/views/directives/ooni-info-explorer-list.directive.html
@@ -1,70 +1,28 @@
-<a ng-click="filterFormOpen = !filterFormOpen" class="filter-toggle" ng-show="!hideFilter">
-  Filter Results
-    <i class="fa fa-chevron-circle-down" ng-class="{open: filterFormOpen}"></i>
-</a>
-<form class="filter-form" ng-show="filterFormOpen && !hideFilter">
-  <div class="form-group inline">
-    <label class="sr-only" for="input">Test Input:</label>
-    <input type="text" class="form-control" ng-model="inputFilter" placeholder="Test Input"/>
-  </div>
-  <div class="form-group inline">
-    <label class="sr-only" for="testName">Test Name:</label>
-    <select name="repeatSelect" id="repeatSelect" ng-model="testNameFilter">
-        <option value="">-- Select Nettest --</option>
-        <option ng-repeat="option in nettests" value="{{option.name}}">{{option.long_name}}</option>
-    </select>
-  </div>
-  <div class="form-group" ng-show="countryCodes">
-    <label class="sr-only" for="countryCode">Country Code:</label>
+<div ooni-filter-list-form
+  query-options="queryOptions"
+  after-filter="filterCallback"
+  >
+</div>
+<div ooni-pagination
+  page-number="queryOptions.pageNumber"
+  go-to="goTo"
+  total="measurements.total"
+  page-size="queryOptions.pageSize">
 
-    <select name="repeatSelectCountry"
-      id="countryCode"
-      ng-model="countryCodeFilter"
-      ng-options="key as value for (key, value) in allCountryCodes">
-        <option value="">-- Select Country Code --</option>
-    </select>
-    <!-- <input type="text" class="form-control" ng-model="countryCodeFilter" placeholder="Country code"/> -->
-  </div>
-  <br ng-show="!countryCodes"/>
-
-  <div class="form-group inline date-range">
-    <label>Date Range</label>
-    <input date-range-picker
-      class="form-control date-picker"
-      type="text"
-      ng-model="dateRangePicker.date"
-      options="dateRangePicker.options"/>
-  </div>
-  <button class="form-group" type="submit" ng-click="filterMeasurements()">Apply Filter</button>
-</form>
+</div>
 
 <ul class="explorer-list">
-  <li ng-repeat="measurement in measurements">
-    <div class="column-1-5">
-      <a href="/measurement/{{ measurement.report_id }}?input={{ encodeInput(measurement.input) }}">{{ measurement.probe_cc}}</a>
-    </div>
-    <div class="column-1-5">{{measurement.test_name}}</div>
-    <div class="column-1-5">{{measurement.input}}</div>
-    <div class="column-1-5">{{measurement.probe_asn}}</div>
-    <div class="column-1-5">{{measurement.test_start_time|date:'shortDate'}}</div>
+  <li ng-repeat="measurement in measurements"
+    ooni-explorer-list-measurement="measurement">
+
   </li>
 </ul>
 
-<ul class="pagination">
-  <li ng-hide="queryOptions.pageNumber <= 0">
-    <a ng-click="goTo(queryOptions.pageNumber - 1)">< Previous</a>
-  </li>
-  <li>
-  </li>
-  <li>
-    {{ queryOptions.pageNumber }}
-  </li>
-  <li ng-hide="queryOptions.pageNumber >= Math.floor(measurements.total / queryOptions.pageSize)">
-    <a ng-click="goTo(queryOptions.pageNumber + 1)">Next ></a>
-  </li>
-  <li>
-    {{ total }} total
-  </li>
-</ul>
+<div ooni-pagination
+  page-number="queryOptions.pageNumber"
+  go-to="goTo"
+  total="measurements.total"
+  page-size="queryOptions.pageSize">
+</div>
 
 

--- a/client/ngapp/views/directives/ooni-pagination.directive.html
+++ b/client/ngapp/views/directives/ooni-pagination.directive.html
@@ -1,0 +1,13 @@
+<ul class="pagination">
+  <li ng-if="pageNumber > 0">
+    <a ng-click="goTo(pageNumber - 1)">« Previous</a>
+  </li><li>
+    {{ pageNumber + 1 }}
+  </li><li ng-hide="pageNumber >= Math.floor(total / pageSize)">
+    <a ng-click="goTo(pageNumber + 1)">Next »</a>
+  </li>
+</ul>
+
+<span>
+  {{ total|number }} measurements
+</span>

--- a/client/ngapp/views/explore.html
+++ b/client/ngapp/views/explore.html
@@ -1,4 +1,4 @@
-<main>
+<main class="explore">
 <p>
   Explore our measurements and reports from various types of tests and countries. Use the filter to narrow down what you're looking for.
 </p>
@@ -11,7 +11,9 @@
     >
   </div> -->
 
-  <div ooni-info-explorer-list
+  <div
+    ng-show="loaded"
+    ooni-info-explorer-list
     get-data-function="loadMeasurements">
   </div>
 </main>

--- a/client/ngapp/views/explore.html
+++ b/client/ngapp/views/explore.html
@@ -5,9 +5,13 @@
   <div ooni-loader
     loaded="loaded">
   </div>
-  <div ooni-grid-wrapper
+  <!-- <div ooni-grid-wrapper
     country-codes="true"
     get-data-function="loadMeasurements"
     >
+  </div> -->
+
+  <div ooni-info-explorer-list
+    get-data-function="loadMeasurements">
   </div>
 </main>

--- a/client/ngapp/views/world.html
+++ b/client/ngapp/views/world.html
@@ -40,23 +40,15 @@
   <div ooni-loader loaded="loaded">
   </div>
 
+  <div ng-show="loaded">
   <h2>Country List</h2>
   <p>
-    Browse the countries below to find a country you want to investigate the tests for:
+    Browse the countries below to find a country you want to investigate the measurements for:
   </p>
 
   <div ooni-info-country-list
     get-data-function="loadReports">
   </div>
-
-  <!-- <div ooni-grid-wrapper
-    hide-filter="true"
-    get-data-function="loadReports"
-    view-row-object-function="viewCountry"
-    custom-column-defs="columnDefs"
-    enable-pagination="false"
-    use-external-pagination="false"
-    use-external-sorting="false">
-  </div> -->
+  </div>
 
 </main>

--- a/client/ngapp/views/world.html
+++ b/client/ngapp/views/world.html
@@ -45,7 +45,11 @@
     Browse the countries below to find a country you want to investigate the tests for:
   </p>
 
-  <div ooni-grid-wrapper
+  <div ooni-info-country-list
+    get-data-function="loadReports">
+  </div>
+
+  <!-- <div ooni-grid-wrapper
     hide-filter="true"
     get-data-function="loadReports"
     view-row-object-function="viewCountry"
@@ -53,6 +57,6 @@
     enable-pagination="false"
     use-external-pagination="false"
     use-external-sorting="false">
-  </div>
+  </div> -->
 
 </main>


### PR DESCRIPTION
This is a series of code changes that should make it easier for @bnvk to visually change the style of the explore page and country view pages (instead of using ui-grid).

## Country View
* Simplified list of countries with amount of measurements in the country
* Filter countries for a quick search (without reload)

![screenshot 2016-03-08 12 57 36](https://cloud.githubusercontent.com/assets/485583/13616128/60ae6afa-e52d-11e5-9cd6-4d202331ef02.png)
* *Idea*: dim the countries in the map if they're not showing up in the filter. 

# Explorer View
* Simplified measurements list view to be more easily manageable
* Broke out filter form 
* Built pagination directive
![screenshot 2016-03-08 14 52 56](https://cloud.githubusercontent.com/assets/485583/13619396/9964ca64-e53d-11e5-95ef-b3b5c3c1f248.png)
