### PR TITLE
Add rel="nofollow" attr to discourage search engines

### DIFF
--- a/client/ngapp/views/nettests/http-requests.html
+++ b/client/ngapp/views/nettests/http-requests.html
@@ -10,7 +10,7 @@
         </div>
         <div>
           <h3>Website</h3>
-            <label for="input">URL: </label> <a href="{{ report.input  }}" target="_blank">{{ report.input  }}</a>
+            <label for="input">URL: </label> <a href="{{ report.input  }}" rel="nofollow" target="_blank">{{ report.input  }}</a>
             <br>
             <label for="experiment_failure">Experiment Failure: </label><span id="experiment-failure">{{ experiment_failure }}</span>
             <br>

--- a/client/ngapp/views/nettests/web-connectivity.html
+++ b/client/ngapp/views/nettests/web-connectivity.html
@@ -10,7 +10,7 @@
         </div>
         <div>
           <h3>Website</h3>
-            <label for="input">URL: </label> <a href="{{ report.input  }}" target="_blank">{{ report.input  }}</a>
+            <label for="input">URL: </label> <a href="{{ report.input  }}" rel="nofollow" target="_blank">{{ report.input  }}</a>
             <br>
             <label for="blocking_reason">Reason for blocking: </label><span id="blocking-reason">{{ report.test_keys.blocking }}</span>
             <br>


### PR DESCRIPTION
This fixes: https://github.com/TheTorProject/ooni-explorer/issues/103