### PR TITLE
css: give `word-wrap: break-word;` to explore.scss

### DIFF
--- a/client/ngapp/styles/_explore.scss
+++ b/client/ngapp/styles/_explore.scss
@@ -8,6 +8,7 @@
     li {
       margin: 0;
       padding: .5rem;
+      word-wrap: break-word;
 
       &:nth-child(odd) {
         background-color: $color-off-white;
@@ -32,12 +33,12 @@
   }
 
   .probe-asn {
-    width: 9%;
+    width: 10%;
     text-align: right;
   }
 
   .start-time {
-    width: 9%;
+    width: 10%;
     text-align: right;
   }
 }


### PR DESCRIPTION
Updates:
+ Give `word-wrap: break-word;` to display too long URLs
+ Tweaks the width of items in the list

Fixes: https://github.com/TheTorProject/ooni-explorer/issues/83

Preview:
![screen shot 2017-04-17 at 22 52 30](https://cloud.githubusercontent.com/assets/1716463/25104434/9f7e239c-23c0-11e7-81bb-87d49d008ab0.png)