### PR TITLE
Fixes lint errors

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -452,11 +452,12 @@ module.exports = function (grunt) {
   });
 
   grunt.registerTask('copy-factbook-data', 'Copy the factbook data', function(target) {
-      if (target == 'dist') {
-        var outputPath = path.resolve(__dirname, appConfig.dist, 'data',
+      var outputPath
+      if (target === 'dist') {
+        outputPath = path.resolve(__dirname, appConfig.dist, 'data',
                                       'factbook');
       } else {
-        var outputPath = path.resolve(__dirname, appConfig.app, 'data',
+        outputPath = path.resolve(__dirname, appConfig.app, 'data',
                                       'factbook');
       }
       grunt.file.mkdir(outputPath);

--- a/server/boot/create-default-tables.js
+++ b/server/boot/create-default-tables.js
@@ -19,7 +19,7 @@ module.exports = function(app) {
     var country_rows = [];
     var countries = require('country-data').countries;
     countries.all.forEach(function(country, idx) {
-        if (country.alpha2 == 'TW') {
+        if (country.alpha2 === 'TW') {
             country.name = 'Taiwan';
         }
         country_rows.push({
@@ -59,7 +59,7 @@ module.exports = function(app) {
     async.mapValues(methodsByCountry, function(methods, iso_alpha2, cb2) {
         console.log("" + iso_alpha2 + "->" + methods);
       app.models.country.findOne({'where': {'iso_alpha2': iso_alpha2}}, function(err, country) {
-        if (err) {console.log(err); return cb2(err)};
+        if (err) {console.log(err); return cb2(err)}
         async.map(methods, function(methodId) {
             app.models.censorship_method.findById(methodId, function(err, method) {
                 country.censorship_methods.add(method);
@@ -70,7 +70,7 @@ module.exports = function(app) {
         })
       });
     }, function(err, results) {
-        if (err) {return cb(err)};
+        if (err) {return cb(err)}
         cb(null, results);
     });
   }
@@ -228,6 +228,6 @@ module.exports = function(app) {
         console.log('Automigrated nettest data');
         app.models.nettest.create(nettest_rows, cb);
       });
-  };
+  }
 
 }

--- a/server/boot/extend-models.js
+++ b/server/boot/extend-models.js
@@ -9,7 +9,7 @@ module.exports = function(app) {
     providers = require('../providers.json');
   }
 
-  var storageHandler = StorageService({
+  var storageHandler = new StorageService({
     provider: 'amazon',
     key: providers.amazon.key,
     keyId: providers.amazon.keyId,


### PR DESCRIPTION
Gruntfile.js:
+ line 455, col 20, Expected '===' and instead saw '=='.
+ line 459, col 24, 'outputPath' is already defined.
+ line 462, col 24, 'outputPath' used out of scope.

server/boot/create-default-tables.js:
+ line 22, col 30, Expected '===' and instead saw '=='.
+ line 62, col 53, Unnecessary semicolon.
+ line 73, col 34, Unnecessary semicolon.
+ line 231, col 4, Unnecessary semicolon.

server/boot/extend-models.js:
+ line 12, col 24, Missing 'new' prefix when invoking a constructor.