### PR TITLE
Fix/test names

### DIFF
--- a/common/models/report.js
+++ b/common/models/report.js
@@ -22,6 +22,10 @@ module.exports = function(Report) {
     if (report_id) {
       apiQuery.report_id = report_id
     }
+    if (test_name) {
+      apiQuery.test_name = test_name
+    }
+
     /*
     if (order) {
       apiQuery.order_by = order.split(' ')[0]

--- a/common/models/report.js
+++ b/common/models/report.js
@@ -26,12 +26,11 @@ module.exports = function(Report) {
       apiQuery.test_name = test_name
     }
 
-    /*
     if (order) {
       apiQuery.order_by = order.split(' ')[0]
       apiQuery.order = order.split(' ')[1]
     }
-    */
+
     if (page_number && page_size) {
       apiQuery.offset = page_number * page_size
       apiQuery.limit = page_size


### PR DESCRIPTION
This fixes the following bug:

1. I go to this page: https://explorer.ooni.torproject.org/country/CM
2. I click on "Filter Results"
3. I select "Facebook Messenger" in the Test Name drop down menu
4. I click "Apply Filter"
I expect to only see Facebook Messenger measurements below. Instead, I just see the normal measurements that were already there, with no difference.

Bug reported by @agrabeli 